### PR TITLE
docs: add JSDoc for Hue API v2 effects structure

### DIFF
--- a/webhook/index.js
+++ b/webhook/index.js
@@ -386,6 +386,24 @@ async function getChildren(types, roomName, uid, ip, key) {
 }
 
 /**
+ * Structure of the Hue API v2 'effects_v2' object (Status).
+ * Based on Hue Developer Portal documentation.
+ *
+ * @typedef {Object} HueEffectsV2Status
+ * @property {string} effect - The active effect (e.g., 'opal', 'fire', 'prism', 'no_effect').
+ * @property {string[]} effect_values - Array of supported effects.
+ * @property {Object} [parameters] - Customization parameters for the effect.
+ * @property {number} [parameters.speed] - Speed of the effect (0.0 - 1.0).
+ * @property {Object} [parameters.color] - Color definition.
+ * @property {Object} [parameters.color.xy] - CIE XY coordinates.
+ * @property {number} parameters.color.xy.x - X coordinate (0.0 - 1.0).
+ * @property {number} parameters.color.xy.y - Y coordinate (0.0 - 1.0).
+ * @property {Object} [parameters.color_temperature] - Color temperature definition.
+ * @property {number} [parameters.color_temperature.mirek] - Mirek value (50 - 1000).
+ * @property {boolean} [parameters.color_temperature.mirek_valid] - Validity of mirek value.
+ */
+
+/**
  * Captures a specific light attribute and adds it to the action object if present.
  * Uses confirmed API v2 paths (status object for effects, direct for others).
  *
@@ -397,8 +415,7 @@ async function getChildren(types, roomName, uid, ip, key) {
  */
 function captureLightAttribute(light, action, parentKey, childKey, logLabel) {
   let value;
-
-  // Resolve value based on known API structure
+  
   if (parentKey === "effects_v2") {
     value = light[parentKey]?.status?.[childKey];
   } else {
@@ -416,6 +433,12 @@ function captureLightAttribute(light, action, parentKey, childKey, logLabel) {
         action.action[parentKey].action = {};
       }
       action.action[parentKey].action[childKey] = value;
+
+      // Capture optional parameters (speed, color variants) if present in status
+      const parameters = light[parentKey]?.status?.parameters;
+      if (parameters) {
+        action.action[parentKey].action.parameters = parameters;
+      }
     } else {
       // Standard write path for others (effects, color_temperature)
       action.action[parentKey][childKey] = value;


### PR DESCRIPTION
docs: add JSDoc for Hue API v2 effects structure and enhance light attribute capturing

* Document the structure of the Hue API v2 'effects_v2' object for better clarity.
* Enhance the captureLightAttribute function to include optional parameters for effects, such as speed and color variants.